### PR TITLE
_includes/headline.html: Remove whitespace from 'DOI </strong>'

### DIFF
--- a/_includes/headline.html
+++ b/_includes/headline.html
@@ -6,7 +6,7 @@
 
     <p>It's almost time to publish the next version of <a href='http://software-carpentry.org/lessons/'>Software Carpentry's lessons</a>, 
     and we need your help! Get together in person or participate remotely to close issues, finish PRs and make our 
-    lessons better than ever in a one day sprint on June 13. Once complete, these lessons will be <strong>published with a DOI
-    </strong>, so all our contributors can get a citation for their hard work.</p>
+    lessons better than ever in a one day sprint on June 13. Once complete, these lessons will be <strong>published with a
+    DOI</strong>, so all our contributors can get a citation for their hard work.</p>
 
 </div>


### PR DESCRIPTION
Otherwise the page renders with a space between "DOI" and the
following comma.
